### PR TITLE
chore: archive repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,18 @@
 # qiita-to-md
 
+> [!CAUTION] > **This repository has been archived.**
+>
+> This package is deprecated in favor of [Qiita CLI](https://github.com/increments/qiita-cli), which provides the `qiita pull` command for downloading articles as Markdown.
+>
+> **Migration:** Install Qiita CLI and use `qiita pull` to download your articles.
+>
+> **Security:** If you have a `.qiita_token.json` file, revoke the token and delete the file.
+>
+> See [#44](https://github.com/MasatoMakino/qiita-to-md/issues/44) for details.
+
 Markdown generator from qiita.com
 
 [![MIT License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat)](LICENSE)
-[![build test](https://github.com/MasatoMakino/qiita-to-md/actions/workflows/ci.yml/badge.svg)](https://github.com/MasatoMakino/qiita-to-md/actions/workflows/ci.yml)
-[![Maintainability](https://api.codeclimate.com/v1/badges/85442a6c02c73e0f380a/maintainability)](https://codeclimate.com/github/MasatoMakino/qiita-to-md/maintainability)
 
 ## Getting Started
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@masatomakino/qiita-to-md",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@masatomakino/qiita-to-md",
-      "version": "0.4.4",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@masatomakino/qiita-to-md",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "description": "Markdown generator from qiita.com",
   "main": "./bin/index.js",
   "types": "./bin/index.d.ts",


### PR DESCRIPTION
## Summary

Closes #44

## Scope

**Changes:**
- Add archival notice to README.md using GitHub Alert syntax
- Remove CI and Code Climate badges (will be stale after archival)
- Bump version to 0.5.0

**Unchanged:**
- MIT License badge (still valid)
- Existing documentation (kept for historical reference)

## Test plan

- [ ] README.md renders archival notice correctly
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Installation and setup instructions added with token configuration guidance.
  * Added examples for running the generator as both a Node.js script and via CLI.
  * Deprecation notice added with migration information.

* **Chores**
  * Version bumped to 0.5.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->